### PR TITLE
Fix epic provider regex

### DIFF
--- a/files/providers.conf
+++ b/files/providers.conf
@@ -42,17 +42,18 @@
    },
    {
       "type": "21",
-      "name": "ePIC",
+      "name": "epic (21.*)",
       "description": "ePIC was founded in 2009 by a consortium of European partners in order to provide PID services for the European Research Community, based on the handle system (TM, https://www.handle.net/ ), for the allocation and resolution of persistent identifiers.",
       "regex": ["^21\\.T?\\d+\\/.+$"],
       "metaresolver": "HANDLER"
    },
    {
-      "type": "11500",
-      "name": "ePIC old",
+      "type": "epic old",
+      "name": "epic old (5 digit ex 11500)",
       "description": "ePIC was founded in 2009 by a consortium of European partners in order to provide PID services for the European Research Community, based on the handle system (TM, https://www.handle.net/ ), for the allocation and resolution of persistent identifiers.",
-      "regex": ["^11500\\/.+$"],
-      "metaresolver": "HANDLER"
+      "regex": ["^\\d{5,5}\\/.+$"],
+      "metaresolver": "HANDLER",
+      "check_type_with_regex": true
    },
    {
       "type": "urn:nbn:de",

--- a/src/main/java/gr/grnet/pidmr/entity/Provider.java
+++ b/src/main/java/gr/grnet/pidmr/entity/Provider.java
@@ -29,6 +29,10 @@ public class Provider {
     private int charactersToBeRemoved;
     @JsonProperty(value = "metaresolver", required = true)
     private String metaresolver;
+    @JsonProperty(value = "check_type_with_regex")
+    //Search for Providers by regex instead of variable type.
+    private boolean checkTypeWithRegex;
+
 
     private Set<String> actions = new HashSet<>();
 

--- a/src/main/java/gr/grnet/pidmr/service/ProviderServiceI.java
+++ b/src/main/java/gr/grnet/pidmr/service/ProviderServiceI.java
@@ -99,10 +99,30 @@ public interface ProviderServiceI {
 
         var providers = getProviders();
 
-        return providers
+        var optionalType = providers
                 .stream()
                 .map(Provider::getType)
                 .filter(tp->belongsTo(pid, tp))
                 .findAny();
+
+        if(optionalType.isPresent()){
+
+            return optionalType;
+        } else{
+
+            return providers
+                    .stream()
+                    .filter(Provider::isCheckTypeWithRegex)
+                    .filter(pr->{
+
+                        var regex = pr.getRegex();
+
+                        return regex
+                                .stream()
+                                .anyMatch(pid::matches);
+                    })
+                    .map(Provider::getType)
+                    .findAny();
+        }
     }
 }

--- a/src/test/java/gr/grnet/MetaresolverEndpointTest.java
+++ b/src/test/java/gr/grnet/MetaresolverEndpointTest.java
@@ -202,6 +202,24 @@ public class MetaresolverEndpointTest {
         assertEquals("http://hdl.handle.net/21.T11973/MR@urn:nbn:fi-fe2021080942632", headers.get("location").getValue());
     }
 
+    @Test
+    public void resolveEpicOldViaAPI(){
+
+        var headers = given()
+                .contentType(ContentType.JSON)
+                .queryParam("pid", "11500/ATHENA-0000-0000-2401-6")
+                .get("/resolve")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .response()
+                .getHeaders();
+
+        assertEquals("GET", headers.get("http-method").getValue());
+        assertEquals("http://hdl.handle.net/11500/ATHENA-0000-0000-2401-6", headers.get("location").getValue());
+    }
+
     public class MockableProvider extends ProviderService {
 
         @Override

--- a/src/test/java/gr/grnet/ProviderEndpointTest.java
+++ b/src/test/java/gr/grnet/ProviderEndpointTest.java
@@ -420,7 +420,7 @@ public class ProviderEndpointTest {
                 .as(Validity.class);
 
         assertTrue(validity.valid);
-        assertEquals("11500", validity.type);
+        assertEquals("epic old", validity.type);
     }
 
     @Test
@@ -548,7 +548,7 @@ public class ProviderEndpointTest {
 
         var informativeResponse = given()
                 .contentType(ContentType.JSON)
-                .queryParam("pid", "13030/tf5p30086k")
+                .queryParam("pid", "lalala/tf5p30086k")
                 .get("/validate")
                 .then()
                 .assertThat()
@@ -556,7 +556,7 @@ public class ProviderEndpointTest {
                 .extract()
                 .as(InformativeResponse.class);
 
-        assertEquals("13030/tf5p30086k doesn't belong to any of the available types.", informativeResponse.message);
+        assertEquals("lalala/tf5p30086k doesn't belong to any of the available types.", informativeResponse.message);
     }
 
     public class MockableProvider extends ProviderService {

--- a/src/test/resources/providers.conf
+++ b/src/test/resources/providers.conf
@@ -42,17 +42,18 @@
    },
    {
       "type": "21",
-      "name": "ePIC",
+      "name": "epic (21.*)",
       "description": "ePIC was founded in 2009 by a consortium of European partners in order to provide PID services for the European Research Community, based on the handle system (TM, https://www.handle.net/ ), for the allocation and resolution of persistent identifiers.",
       "regex": ["^21\\.T?\\d+\\/.+$"],
       "metaresolver": "HANDLER"
    },
    {
-      "type": "11500",
-      "name": "ePIC old",
+      "type": "epic old",
+      "name": "epic old (5 digit ex 11500)",
       "description": "ePIC was founded in 2009 by a consortium of European partners in order to provide PID services for the European Research Community, based on the handle system (TM, https://www.handle.net/ ), for the allocation and resolution of persistent identifiers.",
-      "regex": ["^11500\\/.+$"],
-      "metaresolver": "HANDLER"
+      "regex": ["^\\d{5,5}\\/.+$"],
+      "metaresolver": "HANDLER",
+      "check_type_with_regex": true
    },
    {
       "type": "urn:nbn:de",


### PR DESCRIPTION
We have also added the check_type_with_regex property on providers.conf. This property determines that the provider type will be looked up using the provider regex.