### PR TITLE
[PIDMR-52] Communication issue when retrieving information about a PID mode

### DIFF
--- a/src/main/java/org/grnet/pidmr/exceptionhandler/GeneralExceptionMapper.java
+++ b/src/main/java/org/grnet/pidmr/exceptionhandler/GeneralExceptionMapper.java
@@ -15,7 +15,7 @@ public class GeneralExceptionMapper implements ExceptionMapper<Exception> {
     @Override
     public Response toResponse(Exception e) {
 
-        LOG.error("Server Error", e);
+        LOG.error("Internal Server Error", e);
 
         InformativeResponse response = new InformativeResponse();
         response.message = e.getMessage();

--- a/src/main/java/org/grnet/pidmr/exceptionhandler/ServerErrorExceptionMapper.java
+++ b/src/main/java/org/grnet/pidmr/exceptionhandler/ServerErrorExceptionMapper.java
@@ -1,0 +1,26 @@
+package org.grnet.pidmr.exceptionhandler;
+
+import org.grnet.pidmr.dto.InformativeResponse;
+import org.jboss.logging.Logger;
+
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ServerErrorExceptionMapper implements ExceptionMapper<ServerErrorException> {
+
+    private static final Logger LOG = Logger.getLogger(ServerErrorExceptionMapper.class);
+
+    @Override
+    public Response toResponse(ServerErrorException e) {
+
+        LOG.error("Server Error", e);
+
+        InformativeResponse response = new InformativeResponse();
+        response.message = e.getMessage();
+        response.code = e.getResponse().getStatus();
+        return Response.status(e.getResponse().getStatus()).entity(response).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ quarkus.cache.caffeine."metaresolvers".expire-after-access=24H
 quarkus.cache.caffeine."providers".expire-after-access=24H
 quarkus.cache.caffeine."providersToMap".expire-after-access=24H
 quarkus.cache.caffeine."actions".expire-after-access=24H
+quarkus.cache.caffeine."pidMode".expire-after-access=24H
 
 # open api
 quarkus.smallrye-openapi.path=/open-api
@@ -46,4 +47,3 @@ proxy.resolve.mode.url = http://hdl.handle.net/
 proxy.resolve.mode.url.append.param = ?
 proxy.resolve.mode.body.attribute = hdl
 proxy.resolve.mode.body.attribute.prefix = 21.T11973/MR@
-


### PR DESCRIPTION
To address this issue, we propose implementing two improvements. Firstly, we will increase the timeout value for the HTTP client used in the PID mode information retrieval process.

Additionally, we will introduce a caching mechanism to store the responses obtained from the PID mode information retrieval. This caching strategy will eliminate the need for redundant requests when the same PID information is requested multiple times within a short period.